### PR TITLE
token: add the STX for https://stox.com

### DIFF
--- a/tokens.json
+++ b/tokens.json
@@ -581,6 +581,15 @@
     "decimals": 8,
     "name": "STRC"
   },
+  "STX": {
+    "address": "0x006bea43baa3f7a6f765f14f10a1a1b08334ef45",
+    "decimals": 18,
+    "name": "STX",
+    "title": "STX",
+    "desc": "Prediction Markets Digital Token",
+    "icon": "https://www.stox.com/app/img/favicon.ico",
+    "website": "https://stox.com"
+  },
   "SWT": {
     "address": "0xb9e7f8568e08d5659f5d29c4997173d84cdf2607",
     "decimals": 18,
@@ -716,4 +725,3 @@
     "website": "https://0xproject.com/"
   }
 }
-


### PR DESCRIPTION
Hello. Please add the STX token as the following:

```
  "STX": {
    "address": "0x006bea43baa3f7a6f765f14f10a1a1b08334ef45",
    "decimals": 18,
    "name": "STX",
    "title": "STX",
    "desc": "Prediction Markets Digital Token",
    "icon": "https://www.stox.com/app/img/favicon.ico",
    "website": "https://stox.com"
  },
```